### PR TITLE
Make the Windows #ifdef more universal

### DIFF
--- a/svndumpsanitizer.c
+++ b/svndumpsanitizer.c
@@ -18,7 +18,7 @@
 */
 
 // WIN32 modification by $ergi0
-#ifdef WIN32
+#ifdef _WIN32
 #define _CRT_SECURE_NO_WARNINGS
 #include <sys/types.h>
 #define fseeko _fseeki64


### PR DESCRIPTION
 * WIN32 is only defined by a few compilers, while _WIN32 is defined by all of them
 * See: http://nadeausoftware.com/articles/2012/01/c_c_tip_how_use_compiler_predefined_macros_detect_operating_system#WindowsCygwinnonPOSIXandMinGW