### PR TITLE
Add file options

### DIFF
--- a/svndumpsanitizer.c
+++ b/svndumpsanitizer.c
@@ -1121,7 +1121,7 @@ int main(int argc, char **argv) {
 				exit_with_error(strcat(argv[i], " cannot open include paths file") , 3);
 			}
 			freepaths = 1;
-			fprintf(messages, "Include paths:\n");
+			//fprintf(messages, "Include paths:\n");
 			while ((read = getline(&line, &len, paths)) != -1) {
 				if ((include = (char**)realloc(include, (inc_len + 1) * sizeof(char*))) == NULL) {
 					exit_with_error("realloc failed", 2);
@@ -1130,7 +1130,7 @@ int main(int argc, char **argv) {
 				include[inc_len] = str_malloc(read);
 				line = cleanup_path(line, read);
 				strcpy(include[inc_len], line);
-				fprintf(messages, "\t%s\n", include[inc_len]);
+				//fprintf(messages, "\t%s\n", include[inc_len]);
 				++inc_len;	
 			}
 			fclose(paths);
@@ -1156,7 +1156,7 @@ int main(int argc, char **argv) {
 				exit_with_error(strcat(argv[i], " cannot open exclude paths file") , 3);
 			}
 			freepaths = 1;
-			fprintf(messages, "Exclude paths:\n");
+			//fprintf(messages, "Exclude paths:\n");
 			while ((read = getline(&line, &len, paths)) != -1) {
 				if ((exclude = (char**)realloc(exclude, (exc_len + 1) * sizeof(char*))) == NULL) {
 					exit_with_error("realloc failed", 2);
@@ -1165,7 +1165,7 @@ int main(int argc, char **argv) {
 				exclude[exc_len] = str_malloc(read);
 				line = cleanup_path(line, read);
 				strcpy(exclude[exc_len], line);
-				fprintf(messages, "\t%s\n", exclude[exc_len]);
+				//fprintf(messages, "\t%s\n", exclude[exc_len]);
 				++exc_len;	
 			}
 			fclose(paths);

--- a/svndumpsanitizer.c
+++ b/svndumpsanitizer.c
@@ -939,6 +939,17 @@ void write_mergeinfo(FILE *outfile, mergedata *data, revision *revisions, char *
 	}
 }
 
+char* cleanup_path(char* path, size_t len) {
+	int i = 0;
+	for (; i < len; ++i) {
+		if (path[i] == '\r' || path[i] == '\n') {
+			path[i] = '\0';
+		}
+	}
+	path[len] = '\0';
+	return path;
+}
+
 /*******************************************************************************
  *
  * Main method
@@ -1110,13 +1121,16 @@ int main(int argc, char **argv) {
 				exit_with_error(strcat(argv[i], " cannot open include paths file") , 3);
 			}
 			freepaths = 1;
+			fprintf(messages, "Include paths:\n");
 			while ((read = getline(&line, &len, paths)) != -1) {
 				if ((include = (char**)realloc(include, (inc_len + 1) * sizeof(char*))) == NULL) {
 					exit_with_error("realloc failed", 2);
 				}
 
-				include[inc_len] = (char*)malloc(read);
+				include[inc_len] = str_malloc(read);
+				line = cleanup_path(line, read);
 				strcpy(include[inc_len], line);
+				fprintf(messages, "\t%s\n", include[inc_len]);
 				++inc_len;	
 			}
 			fclose(paths);
@@ -1142,13 +1156,16 @@ int main(int argc, char **argv) {
 				exit_with_error(strcat(argv[i], " cannot open exclude paths file") , 3);
 			}
 			freepaths = 1;
+			fprintf(messages, "Exclude paths:\n");
 			while ((read = getline(&line, &len, paths)) != -1) {
 				if ((exclude = (char**)realloc(exclude, (exc_len + 1) * sizeof(char*))) == NULL) {
 					exit_with_error("realloc failed", 2);
 				}
 
-				exclude[exc_len] = (char*)malloc(read);
+				exclude[exc_len] = str_malloc(read);
+				line = cleanup_path(line, read);
 				strcpy(exclude[exc_len], line);
+				fprintf(messages, "\t%s\n", exclude[exc_len]);
 				++exc_len;	
 			}
 			fclose(paths);

--- a/tests/test_svndumpsanitizer.sh
+++ b/tests/test_svndumpsanitizer.sh
@@ -26,7 +26,7 @@ fail=0
 pass=0
 messages=""
 pushd `dirname $0`
-for subdir in `ls -l | grep ^d | sed 's/.*[ \t]//'` ; do
+for subdir in `ls -l | grep ^d | sed 's/.* //g'` ; do
 	pushd $subdir
 	if [ -e temp.dump ] ; then
 		rm -f temp.dump


### PR DESCRIPTION
In case that you are interested, here is a PR that allows to define the include and exlude paths be read from a file.
I tried to get the tests running locally, but without success. 
Currently it has the caveat, that the program will crash at the end, when one uses the --include and --include-paths option, because a) it does not prevent it and b) it tries to free memory that was not allocated via malloc (the pointer pointing to the argv strings.)
Anyway, feel free to use it or drop. I wouldn't mind at all :-)